### PR TITLE
build: bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.3.1",
-    "@sveltejs/kit": "^2.9.0",
-    "@sveltejs/vite-plugin-svelte": "^4.0.2",
+    "@sveltejs/kit": "^2.12.1",
+    "@sveltejs/vite-plugin-svelte": "^4.0.3",
     "@types/jsonwebtoken": "^9.0.7",
-    "svelte": "^5.8.1",
+    "svelte": "^5.14.1",
     "svelte-check": "^4.1.1",
     "tslib": "^2.8.1",
     "typescript": "^5.7.2",
@@ -23,7 +23,7 @@
   "type": "module",
   "dependencies": {
     "@supabase/ssr": "^0.5.2",
-    "@supabase/supabase-js": "^2.47.2",
+    "@supabase/supabase-js": "^2.47.8",
     "jose": "^5.9.6"
   }
 }


### PR DESCRIPTION
@sveltejs/kit 2.9.0 → 2.12.1
@sveltejs/vite-plugin-svelte 4.0.2 → 4.0.3
svelte 5.8.1 → 5.14.1
@supabase/supabase-js 2.47.2 → 2.47.8