### PR TITLE
fix: show change e password form if providers contains email

### DIFF
--- a/src/routes/(authenticated)/self/+page.svelte
+++ b/src/routes/(authenticated)/self/+page.svelte
@@ -2,7 +2,10 @@
   let { data, form } = $props()
 
   let { session } = $state(data)
-  const provider = session?.user.app_metadata.provider
+  const providers = session?.user.app_metadata.providers
+  const has_email_provider = providers 
+    ? providers.some((p: string) => p === 'email') 
+    : session?.user.app_metadata.provider === 'email'
 </script>
 
 {#if session}
@@ -28,7 +31,7 @@
     <input name="phone" type="text">
     <button style="margin-top: 12px;">Update</button>
   </form>
-  {#if provider === "email"}
+  {#if has_email_provider}
     <form method="POST" action="?/update_password">
       Change your password:
       <input name="password" type="password">


### PR DESCRIPTION
## Current Behavior
If a user has multiple providers associated with their account, which contains `email` but the primary provider isn't `email`, then the form for updating a password on the `/self` page will not render.

The primary provider is stored in `session.user.app_metadata.provider`. If there are multiple providers, everything is stored in `session.user.app_metadata.providers` (but the primary is still stored in `provider`).

## New Behavior
We first check if there are multiple providers, then see if one of them is `email`. If there are not multiple providers, then we only check `provider`.