### PR TITLE
fix: secure anonymous email user conversion

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,9 +2,11 @@ import { fail } from "@sveltejs/kit"
 
 export const Fail = (
   error: { 
+    email?: string;
     message: string; 
     status?: number; 
     name?: string;
+    password_prompt?: boolean;
     phone?: string;
     verify?: boolean;
   }, 

--- a/src/routes/(authenticated)/self/+page.server.ts
+++ b/src/routes/(authenticated)/self/+page.server.ts
@@ -38,7 +38,12 @@ export const actions = {
     if (error)
       return Fail(error)
 
-    return { message: 'Please check your email for the OTP code and enter it below.' , verify: true, email }
+    return { 
+      message: 'Please check your email for the OTP code and enter it below, along with your new password.' , 
+      verify: true, 
+      password_prompt: true, 
+      email 
+    }
   },
   convert_provider: async({ request, locals: { supabase } }) => {
     const formData = await request.formData()
@@ -148,25 +153,50 @@ export const actions = {
     return { message: 'Please check your phone for the OTP code and enter it below.' , verify: true, phone }
   },
   verify_otp: async ({ request, locals: { supabase } }) => {
+    /**
+     * This action is used to update a phone number or 
+     * update an email address when converting an anonymous user.
+     */
     const formData = await request.formData()
     const otp = formData.get('otp') as string
     const phone = formData.get('phone') as string
+    const email = formData.get('email') as string
+    const password = formData.get('password') as string
 
     if (!otp) {
       return Fail(
-        { message: 'Please enter an OTP.', verify: true, phone }
+        { message: 'Please enter an OTP.', verify: true, phone, email, password_prompt: password ? false : true }
       )
     }
 
-    const { error } = await supabase.auth.verifyOtp({
-      phone,
-      type: 'phone_change',
-      token: otp
-    })
+    if (phone) {
+      const { error } = await supabase.auth.verifyOtp({
+        phone,
+        type: 'phone_change',
+        token: otp
+      })
 
-    if (error)
-      return Fail({ message: error.message, verify: true, phone })
+      if (error)
+        return Fail({ message: error.message, verify: true, phone })
 
-    return { message: 'Your phone number has been changed.' , verify: false }
+    } else if (email) {
+      const { error } = await supabase.auth.verifyOtp({
+        email,
+        type: 'email_change',
+        token: otp
+      })
+
+      if (error)
+        return Fail({ message: error.message, verify: true, email, password_prompt: true })
+
+      const { error: updateError } = await supabase.auth.updateUser({
+        password
+      })
+
+      if (updateError)
+        return Fail({ message: updateError.message, verify: true, email, password_prompt: true })
+    }
+
+    return { message: 'Success!' , verify: false, password_prompt: false }
   }
 }

--- a/src/routes/(authenticated)/self/+page.server.ts
+++ b/src/routes/(authenticated)/self/+page.server.ts
@@ -33,7 +33,7 @@ export const actions = {
       })
     }
 
-    const { error } = await supabase.auth.updateUser({ email }, { emailRedirectTo: 'http://localhost:5173/self' })
+    const { error } = await supabase.auth.updateUser({ email })
 
     if (error)
       return Fail(error)

--- a/src/routes/(authenticated)/self/+page.server.ts
+++ b/src/routes/(authenticated)/self/+page.server.ts
@@ -26,20 +26,19 @@ export const actions = {
   convert_email: async({ request, locals: { supabase } }) => {
     const formData = await request.formData()
     const email = formData.get('email') as string
-    const password = formData.get('password') as string
 
-    if (!email || !password) {
+    if (!email) {
       return Fail({
-        message: 'Please provide your email address and a password.'
+        message: 'Please provide your email address.'
       })
     }
 
-    const { error } = await supabase.auth.updateUser({ email, password }, { emailRedirectTo: 'http://localhost:5173/self'})
+    const { error } = await supabase.auth.updateUser({ email }, { emailRedirectTo: 'http://localhost:5173/self' })
 
     if (error)
       return Fail(error)
 
-    return { message: 'Please check your email to continue.' }
+    return { message: 'Please check your email for the OTP code and enter it below.' , verify: true, email }
   },
   convert_provider: async({ request, locals: { supabase } }) => {
     const formData = await request.formData()

--- a/src/routes/(authenticated)/self/+page.svelte
+++ b/src/routes/(authenticated)/self/+page.svelte
@@ -3,6 +3,7 @@
 
   let { session } = $state(data)
   const providers = session?.user.app_metadata.providers
+  console.log(providers)
   const has_email_provider = providers 
     ? providers.some((p: string) => p === 'email') 
     : session?.user.app_metadata.provider === 'email'
@@ -46,7 +47,6 @@
     <form method="POST" action="?/convert_email">
       Convert to a permanent user:
       <input name="email" type="email" placeholder="email">
-      <input name="password" type="password" placeholder="password">
       <button style="margin-top: 12px;">Use email auth</button>
     </form>
   {/if}
@@ -60,8 +60,9 @@
 {/if}
 {#if form?.verify}
   <form method="POST" action="?/verify_otp">
-    <input name="otp" placeholder={`OTP sent to ${form?.phone}`} type="text">
+    <input name="otp" placeholder={`OTP sent to ${form?.phone ?? form?.email}`} type="text">
     <input name="phone" type="hidden" value={form?.phone}>
+    <input name="email" type="hidden" value={form?.email}>
     <button style="margin-top: 12px;">Verify</button>
   </form>
 {/if}

--- a/src/routes/(authenticated)/self/+page.svelte
+++ b/src/routes/(authenticated)/self/+page.svelte
@@ -59,10 +59,13 @@
   <p style="color: red;">{form.error}</p>
 {/if}
 {#if form?.verify}
-  <form method="POST" action="?/verify_otp">
-    <input name="otp" placeholder={`OTP sent to ${form?.phone ?? form?.email}`} type="text">
-    <input name="phone" type="hidden" value={form?.phone}>
-    <input name="email" type="hidden" value={form?.email}>
+  <form method="POST" action="?/verify_otp" style="display: flex; flex-direction: column; width: 25%">
+    <input name="otp" width="200" placeholder={`OTP sent to ${form?.phone ?? form?.email}`} type="text">
+    {#if form?.password_prompt}
+    <input name="password" placeholder="Enter new password" type="password">
+    {/if}
+    {#if form?.phone}<input name="phone" type="hidden" value={form.phone}>{/if}
+    {#if form?.email}<input name="email" type="hidden" value={form.email}>{/if}
     <button style="margin-top: 12px;">Verify</button>
   </form>
 {/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,9 +8,7 @@
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event, _session) => {
-      console.log(event)
       if (_session?.expires_at !== session?.expires_at) {
-        console.log('invalidating', event)
         invalidate('supabase:auth')
       }
     })

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,7 +8,9 @@
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event, _session) => {
+      console.log(event)
       if (_session?.expires_at !== session?.expires_at) {
+        console.log('invalidating', event)
         invalidate('supabase:auth')
       }
     })


### PR DESCRIPTION
## Old Behavior

When converting an anonymous user to an email user, we were updating the email and password at the same time. This allows situations where someone can convert to a permanent user with an email address they do not control.

## New Behavior

We update the email address first, which sends an OTP to it. The user is then prompted for the OTP and their desired password. If the OTP is wrong, the conversion fails.