### PR TITLE
feat: add getValidatedSession

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/publi
 import { createServerClient } from '@supabase/ssr'
 import { redirect } from '@sveltejs/kit'
 import type { Session } from '@supabase/supabase-js'
+import { getValidatedSession } from '$lib/utils.js'
 
 export const handle = async ({ event, resolve }) => {
   event.locals.supabase = createServerClient(
@@ -27,65 +28,7 @@ export const handle = async ({ event, resolve }) => {
    * wouldn't correctly update data on its page.
    */
   event.locals.getSession = async (): Promise<Session | null> => {
-    const { data: { session } } = await event.locals.supabase.auth.getSession()
-
-    if (!session) return null
-
-    /* We wrap getClaims in a try/catch, because it could throw. */
-    try {
-      /**
-       * If your project is using symmetric JWTs,
-       * getClaims makes a network call to your Supabase instance.
-       * To avoid this, see our hooks code in v0.13.0 to validate
-       * and get claims using your JWT secret.
-       * 
-       * We pass the access_token into getClaims, otherwise it
-       * would call getSession itself - which we've already done above.
-       * 
-       * If you need data that is only returned from `getUser`,
-       * then you can substitute it here and assign accordingly in the return statement.
-       */
-      const { data, error } = await event.locals.supabase.auth.getClaims(session.access_token)
-
-      if (error || !data) return null
-
-      const { claims } = data
-
-      /**
-       * Return a Session, created from validated claims.
-       * 
-       * For security, the only items you should use from `session` are the access and refresh tokens.
-       * 
-       * Most of these properties are required for functionality or typing.
-       * Add any data needed for your layouts or pages.
-       * 
-       * Here are the properties which aren't required, but we use them in the demo:
-       * `user.user_metadata.avatar_url`
-       * `user.user_metadata.nickname`
-       * `user.email`
-       * `user.phone`
-       */
-      return {
-        access_token: session.access_token,
-        refresh_token: session.refresh_token,
-        expires_at: claims.exp,
-        expires_in: claims.exp - Math.round(Date.now() / 1000),
-        token_type: 'bearer',
-        user: {
-          app_metadata: claims.app_metadata ?? {},
-          aud: 'authenticated',
-          created_at: '', // only found in session.user or getUser
-          id: claims.sub,
-          email: claims.email,
-          phone: claims.phone,
-          user_metadata: claims.user_metadata ?? {},
-          is_anonymous: claims.is_anonymous
-        }
-      }
-    } catch (err) {
-      console.error(err)
-      return null
-    }
+    return await getValidatedSession(event.locals.supabase)
   }
 
   const session = await event.locals.getSession()

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,63 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+export const getValidatedSession = async (supabase: SupabaseClient) => {
+  const session = (await supabase.auth.getSession()).data.session
+
+  if (!session) return null
+
+  /* We wrap getClaims in a try/catch, because it could throw. */
+  try {
+    /**
+     * If your project is using symmetric JWTs,
+     * getClaims makes a network call to your Supabase instance.
+     * To avoid this, see our hooks code in v0.13.0 to validate
+     * and get claims using your JWT secret.
+     * 
+     * We pass the access_token into getClaims, otherwise it
+     * would call getSession itself - which we've already done above.
+     * 
+     * If you need data that is only returned from `getUser`,
+     * then you can substitute it here and assign accordingly in the return statement.
+     */
+    const { data, error } = await supabase.auth.getClaims(session.access_token)
+
+    if (error || !data) return null
+
+    const { claims } = data
+
+    /**
+     * Return a Session, created from validated claims.
+     * 
+     * For security, the only items you should use from `session` are the access and refresh tokens.
+     * 
+     * Most of these properties are required for functionality or typing.
+     * Add any data needed for your layouts or pages.
+     * 
+     * Here are the properties which aren't required, but we use them in the demo:
+     * `user.user_metadata.avatar_url`
+     * `user.user_metadata.nickname`
+     * `user.email`
+     * `user.phone`
+     */
+    return {
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+      expires_at: claims.exp,
+      expires_in: claims.exp - Math.round(Date.now() / 1000),
+      token_type: 'bearer',
+      user: {
+        app_metadata: claims.app_metadata ?? {},
+        aud: 'authenticated',
+        created_at: '', // only found in session.user or getUser
+        id: claims.sub,
+        email: claims.email,
+        phone: claims.phone,
+        user_metadata: claims.user_metadata ?? {},
+        is_anonymous: claims.is_anonymous
+      }
+    }
+  } catch (err) {
+    console.error(err)
+    return null
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,8 @@
 import type { SupabaseClient, Session } from "@supabase/supabase-js"
 
+/**
+ * Validate a session on the client or server side.
+ */
 export const getValidatedSession = async (supabase: SupabaseClient): Promise<Session | null> => {
   const session = (await supabase.auth.getSession()).data.session
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,8 +10,6 @@ export const getValidatedSession = async (supabase: SupabaseClient): Promise<Ses
     /**
      * If your project is using symmetric JWTs,
      * getClaims makes a network call to your Supabase instance.
-     * To avoid this, see our hooks code in v0.13.0 to validate
-     * and get claims using your JWT secret.
      * 
      * We pass the access_token into getClaims, otherwise it
      * would call getSession itself - which we've already done above.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import type { SupabaseClient } from "@supabase/supabase-js"
+import type { SupabaseClient, Session } from "@supabase/supabase-js"
 
-export const getValidatedSession = async (supabase: SupabaseClient) => {
+export const getValidatedSession = async (supabase: SupabaseClient): Promise<Session | null> => {
   const session = (await supabase.auth.getSession()).data.session
 
   if (!session) return null

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,4 +1,5 @@
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public'
+import { getValidatedSession } from '$lib/utils.js'
 import { createBrowserClient, createServerClient, isBrowser } from '@supabase/ssr'
 
 export const load = async ({ fetch, data, depends }) => {
@@ -17,7 +18,7 @@ export const load = async ({ fetch, data, depends }) => {
         }
       })
 
-  const session = isBrowser() ? (await supabase.auth.getSession()).data.session : data.session
+  const session = isBrowser() ? await getValidatedSession(supabase) : data.session
 
   return { supabase, session }
 }


### PR DESCRIPTION
This function allows you to get a validated session on either the server side or client side. It works exactly the same as `event.locals.getSession()` did before this change.

We currently use this in `src/hook.server.ts` and `src/+layout.ts`.